### PR TITLE
Update build.plist

### DIFF
--- a/build.plist
+++ b/build.plist
@@ -23,6 +23,7 @@
 			<string>no-shared</string>
 			<string>no-gost</string>
 			<string>no-asm</string>
+			<string>no-async</string>
 		</array>
 		<key>buildArchSpecificArgs</key>
 		<dict>


### PR DESCRIPTION
To avoid non-public references to _getcontext, _makecontext, _setcontext, async_posix has to be disabled. It's only useful if you have an engine capable of offloading crypto work asynchronously (which typically means specialist hardware). 

[https://github.com/openssl/openssl/issues/2545](url)